### PR TITLE
Feature: 홈 페이지 퍼블리싱 및 컴포넌트 컨벤션 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,19 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 import Inventory from './pages/Inventory';
 import BottomNavigationLayout from './components/layout/BottomNavigation/BottomNavigationLayout';
-
-const Header = styled.header`
-  ${({ theme }) => css`
-    ${theme.textStyles.H_B_32};
-    color: ${theme.colors.primary[700]};
-  `}
-`;
+import Home from './pages/home';
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    element: <Header>Style Test</Header>,
-    errorElement: <div>오류!</div>,
-    children: [],
-  },
-  {
-    path: 'inventory',
     element: <BottomNavigationLayout />,
+    errorElement: <div>오류!</div>,
     children: [
       {
-        index: true,
+        path: '/',
+        element: <Home />,
+      },
+      {
+        path: 'inventory',
         element: <Inventory />,
       },
     ],

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -61,7 +61,7 @@ const getVariantStyle = (theme: any, variant: string, color: string = 'primary')
   }
 };
 
-export const Button = ({
+export default function Button({
   label,
   onClick,
   disabled,
@@ -73,7 +73,7 @@ export const Button = ({
   className,
   color = 'primary',
   ...props
-}: ButtonProps) => {
+}: ButtonProps) {
   const isIconOnly = !!icon && !label;
   const isIconWithLabel = !!icon && !!label;
 
@@ -111,7 +111,7 @@ export const Button = ({
       {label}
     </TextButton>
   );
-};
+}
 
 const IconButton = styled.button<Pick<ButtonProps, 'variant' | 'size' | 'color'>>`
   ${({ theme, variant = 'contained', size = 'medium', color = 'primary' }) => {

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -9,16 +9,18 @@ interface CheckboxProps {
   disabled?: boolean;
 }
 
-export const Checkbox = ({ checked, onChange, disabled }: CheckboxProps) => (
-  <CheckboxWrapper
-    checked={checked}
-    disabled={disabled}
-    onClick={() => !disabled && onChange(!checked)}
-    tabIndex={0}
-  >
-    {checked && <CheckIcon icon={checkIcon} />}
-  </CheckboxWrapper>
-);
+export default function Checkbox({ checked, onChange, disabled }: CheckboxProps) {
+  return (
+    <CheckboxWrapper
+      checked={checked}
+      disabled={disabled}
+      onClick={() => !disabled && onChange(!checked)}
+      tabIndex={0}
+    >
+      {checked && <CheckIcon icon={checkIcon} />}
+    </CheckboxWrapper>
+  );
+}
 
 const CheckboxWrapper = styled.button<{ checked: boolean; disabled?: boolean }>`
   ${({ theme, checked, disabled }) => css`

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Icon } from '@iconify/react';
 import addIcon from '@iconify-icons/material-symbols/add';
+import { Button } from './Button';
 
 const HEADER_HEIGHT = 60;
 const DRAWER_HEADER_HEIGHT = 60;
@@ -27,7 +28,7 @@ export const Drawer = ({ children, isOpen = false, onToggle, onAdd, itemCount = 
   const contentRef = useRef<HTMLDivElement>(null);
   const [windowHeight, setWindowHeight] = useState(window.innerHeight);
 
-  const bottomNavHeight = 100;
+  const bottomNavHeight = 20;
 
   const updateWindowHeight = useCallback(() => {
     setWindowHeight(window.innerHeight);
@@ -113,38 +114,30 @@ export const Drawer = ({ children, isOpen = false, onToggle, onAdd, itemCount = 
   };
 
   return (
-    <DrawerContainer
-      ref={drawerRef}
-      isOpen={isOpen}
-      style={{ transform: `translateX(-50%) translateY(${currentY}px)` }}
-    >
-      <DrawerHandle
-        onClick={handleHandleClick}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      />
-      <DrawerContent
-        ref={contentRef}
+    <>
+      <DrawerContainer
+        ref={drawerRef}
+        isOpen={isOpen}
+        style={{ transform: `translateX(-50%) translateY(${currentY}px)` }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
-        {children}
-      </DrawerContent>
-      {isOpen && (
+        <DrawerHandle onClick={handleHandleClick} />
+        <DrawerContent ref={contentRef}>{children}</DrawerContent>
+      </DrawerContainer>
+      {isOpen && onAdd && (
         <AddButtonContainer>
-          <AddButton onClick={onAdd}>
-            <Icon
-              icon={addIcon}
-              width="24"
-              height="24"
-            />
-            <span>할일 추가</span>
-          </AddButton>
+          <Button
+            label="할일 추가"
+            onClick={onAdd}
+            fullWidth
+            color="primary"
+            icon={<Icon icon={addIcon} />}
+          />
         </AddButtonContainer>
       )}
-    </DrawerContainer>
+    </>
   );
 };
 
@@ -192,6 +185,7 @@ const DrawerContent = styled.div`
 const AddButtonContainer = styled.div`
   ${({ theme }) => css`
     position: fixed;
+    padding: 0 20px;
     bottom: 0;
     left: 50%;
     transform: translateX(-50%);
@@ -199,34 +193,9 @@ const AddButtonContainer = styled.div`
     max-width: 480px;
     height: 80px;
     background: ${theme.colors.white};
-    border-top: 1px solid ${theme.colors.gray[200]};
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 100;
-  `}
-`;
-
-const AddButton = styled.button`
-  ${({ theme }) => css`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 24px;
-    background: ${theme.colors.primary[500]};
-    color: ${theme.colors.white};
-    border: none;
-    border-radius: 8px;
-    ${theme.textStyles.T_SB_14};
-    cursor: pointer;
-    transition: background-color 0.2s;
-
-    &:hover {
-      background: ${theme.colors.primary[600]};
-    }
-
-    &:active {
-      background: ${theme.colors.primary[700]};
-    }
   `}
 `;

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -21,7 +21,7 @@ interface DrawerProps {
   itemCount?: number;
 }
 
-export const Drawer = ({ children, isOpen = false, onToggle, onAdd, itemCount = 0 }: DrawerProps) => {
+export default function Drawer({ children, isOpen = false, onToggle, onAdd, itemCount = 0 }: DrawerProps) {
   const [dragStart, setDragStart] = useState<number | null>(null);
   const [currentY, setCurrentY] = useState(0);
   const drawerRef = useRef<HTMLDivElement>(null);
@@ -139,7 +139,7 @@ export const Drawer = ({ children, isOpen = false, onToggle, onAdd, itemCount = 
       )}
     </>
   );
-};
+}
 
 const DrawerContainer = styled.div<{ isOpen: boolean }>`
   ${({ theme, isOpen }) => css`

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Icon } from '@iconify/react';
 import addIcon from '@iconify-icons/material-symbols/add';
-import { Button } from './Button';
+import Button from './Button';
 
 const HEADER_HEIGHT = 60;
 const DRAWER_HEADER_HEIGHT = 60;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -16,7 +16,13 @@ interface DropdownProps {
   onChange?: (value: string | number) => void;
 }
 
-export const Dropdown = ({ fullWidth, placeholder = '선택하세요', loading, options = [], onChange }: DropdownProps) => {
+export default function Dropdown({
+  fullWidth,
+  placeholder = '선택하세요',
+  loading,
+  options = [],
+  onChange,
+}: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<{ label: string; value: string | number } | undefined>(undefined);
 
@@ -53,7 +59,7 @@ export const Dropdown = ({ fullWidth, placeholder = '선택하세요', loading, 
       {isOpen && loading && <LoadingItem>로딩 중...</LoadingItem>}
     </Wrapper>
   );
-};
+}
 
 const Wrapper = styled.div<{ fullWidth?: boolean }>`
   position: relative;

--- a/src/components/common/ProgressBar.tsx
+++ b/src/components/common/ProgressBar.tsx
@@ -10,7 +10,7 @@ interface ProgressBarProps {
   height: number;
 }
 
-export const ProgressBar = ({ variant, label, total, current, width, height }: ProgressBarProps) => {
+export default function ProgressBar({ variant, label, total, current, width, height }: ProgressBarProps) {
   const progressPercentage = total > 0 ? (current / total) * 100 : 0;
 
   return (
@@ -28,7 +28,7 @@ export const ProgressBar = ({ variant, label, total, current, width, height }: P
       </Wrapper>
     </Container>
   );
-};
+}
 
 const Container = styled.div<{ width: number }>`
   display: flex;

--- a/src/components/common/TodoItem.tsx
+++ b/src/components/common/TodoItem.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { Checkbox } from './CheckBox';
+import Checkbox from './CheckBox';
 
 type CategoryType = '공부' | '운동' | '업무' | '생활' | '기타';
 
@@ -36,7 +36,7 @@ const categoryColors = {
   },
 };
 
-export const TodoItem = ({ id, text, checked, category, onCheck }: TodoItemProps) => {
+export default function TodoItem({ id, text, checked, category, onCheck }: TodoItemProps) {
   return (
     <ItemWrapper category={category}>
       <Checkbox
@@ -47,7 +47,7 @@ export const TodoItem = ({ id, text, checked, category, onCheck }: TodoItemProps
       {category && <CategoryLabel category={category}>{category}</CategoryLabel>}
     </ItemWrapper>
   );
-};
+}
 
 const ItemWrapper = styled.div<{ category?: CategoryType }>`
   ${({ theme, category }) => css`
@@ -75,7 +75,9 @@ const ItemText = styled.span<{ checked: boolean }>`
     color: ${theme.colors.black};
     text-decoration: ${checked ? 'line-through' : 'none'};
     opacity: ${checked ? 0.6 : 1};
-    transition: opacity 0.2s, text-decoration 0.2s;
+    transition:
+      opacity 0.2s,
+      text-decoration 0.2s;
   `}
 `;
 

--- a/src/components/common/tilemap.tsx
+++ b/src/components/common/tilemap.tsx
@@ -59,7 +59,7 @@ const axialToPixel = (q: number, r: number, size: number): [number, number] => {
   return [x, y];
 };
 
-export const TileMap = () => {
+export default function TileMap() {
   const [mapSeed, setMapSeed] = useState(1);
   const [completedStep, setCompletedStep] = useState(0);
   const [taskCategories, setTaskCategories] = useState<{ [key: number]: CategoryKey }>({});
@@ -174,16 +174,15 @@ export const TileMap = () => {
       </MapContainer>
     </Container>
   );
-};
+}
 
 const Container = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   overflow: hidden;
-
 `;
 
 const MapContainer = styled.div`

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
 
-import { Drawer } from '../../components/common/Drawer';
-import { TodoItem } from '../../components/common/TodoItem';
-import { ProgressBar } from '../../components/common/ProgressBar';
+import Drawer from '../../components/common/Drawer';
+import TodoItem from '../../components/common/TodoItem';
+import ProgressBar from '../../components/common/ProgressBar';
 import TileMap from '../../components/common/tilemap';
 
 const mockTodos = [

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+
+import { Drawer } from '../../components/common/Drawer';
+import { TodoItem } from '../../components/common/TodoItem';
+import { ProgressBar } from '../../components/common/ProgressBar';
+import TileMap from '../../components/common/tilemap';
+
+const mockTodos = [
+  { id: '1', text: '프로젝트 초기 설정하기', checked: true, category: '업무' as const },
+  { id: '2', text: '컴포넌트 라이브러리 조사', checked: true, category: '업무' as const },
+  { id: '3', text: '디자인 시스템 정의', checked: false, category: '업무' as const },
+  { id: '4', text: '운동하기', checked: false, category: '운동' as const },
+  { id: '5', text: '장보기', checked: true, category: '생활' as const },
+];
+
+const mockUser = {
+  name: '레벨린',
+  level: 5,
+  exp: 75,
+  maxExp: 100,
+};
+
+export default function Home() {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [todos, setTodos] = useState(mockTodos);
+
+  const handleToggleDrawer = (isOpen: boolean) => {
+    setIsDrawerOpen(isOpen);
+  };
+
+  const handleAddTodo = () => {
+    console.log('Add new todo');
+  };
+
+  const handleCheckTodo = (id: string, checked: boolean) => {
+    setTodos((prevTodos) => prevTodos.map((todo) => (todo.id === id ? { ...todo, checked } : todo)));
+  };
+
+  return (
+    <Container>
+      <Header>
+        <span>임시 헤더</span>
+      </Header>
+      <UserInfo>
+        <NameLevelRow>
+          <span>{mockUser.name}</span>
+          <Level>Lv. {mockUser.level}</Level>
+        </NameLevelRow>
+        <ProgressBar
+          variant="exp"
+          label="EXP"
+          total={mockUser.maxExp}
+          current={mockUser.exp}
+          width={160}
+          height={16}
+        />
+      </UserInfo>
+      <Content>
+        <TileMap />
+      </Content>
+      <Drawer
+        isOpen={isDrawerOpen}
+        onToggle={handleToggleDrawer}
+        onAdd={handleAddTodo}
+        itemCount={todos.length}
+      >
+        <TodoList>
+          {todos.map((todo) => (
+            <TodoItem
+              key={todo.id}
+              {...todo}
+              onCheck={(checked) => handleCheckTodo(todo.id, checked)}
+            />
+          ))}
+        </TodoList>
+      </Drawer>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  position: relative;
+  overflow: hidden;
+`;
+
+const Header = styled.header`
+  height: 60px;
+  padding: 0 20px;
+  background-color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: bold;
+  border-bottom: 1px solid #e0e0e0;
+`;
+
+const UserInfo = styled.div`
+  position: absolute;
+  top: 72px;
+  right: 20px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const NameLevelRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding-left: 9px;
+`;
+
+const Level = styled.span`
+  ${({ theme }) => theme.textStyles.B_R_14};
+`;
+
+const Content = styled.main`
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 100px;
+`;
+
+const TodoList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;


### PR DESCRIPTION
## 🧑‍💻 작업 내용

### 홈 페이지 퍼블리싱
- `Drawer`, `TodoItem`, `ProgressBar`, `TileMap` 컴포넌트를 사용하여 홈 페이지의 기본적인 레이아웃과 UI를 구현했습니다.
- 헤더의 경우 기영님께서 작업해주시기로 하여 임시 헤더 영역만 할당해두었습니다. 추가되는 상단 헤더 확인 후, 추후 적용하겠습니다.

### 컴포넌트 export 방식 수정
- 기존에 혼용되던 `export const` 방식을 `export default function`으로 통일하였습니다.
  - 기영님 작업 코드와 스타일을 통일하여 일관성을 확보했습니다.
  - 컴포넌트의 단일 책임 원칙을 준수하는 설계를 코드 구조에 반영하고자, 한 파일에 하나의 주된 컴포넌트를 정의하는 것이 적합하다고 생각했습니다. 이에 따라 각 모듈의 대표성을 가장 잘 나타내는 export default 방식으로 통일하였습니다.

---

## 🧐 추가 논의 사항

- Drawer에서는 기본 2개 투두를 출력하며, 드래그 시 전체 투두 + 추가하기 버튼을 추가합니다. 페이지 뎁스가 깊어지는걸 선호하지 않아 drawer을 적용해보았는데 더 나은 UX 있다면 의견 제시해주세요!
